### PR TITLE
AppStore　商品詳細ビュー・カート機能を実装

### DIFF
--- a/AppStore.xcodeproj/project.pbxproj
+++ b/AppStore.xcodeproj/project.pbxproj
@@ -7,7 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		83478B6B24A7BE0E00C6311C /* Cart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83478B6A24A7BE0E00C6311C /* Cart.swift */; };
 		8347F25D24A6AE8F006B7D8A /* AddItemViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8347F25C24A6AE8F006B7D8A /* AddItemViewController.swift */; };
+		8347F26724A6EDB9006B7D8A /* DetailTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8347F26624A6EDB9006B7D8A /* DetailTableViewController.swift */; };
+		8347F26924A6EDE7006B7D8A /* DetailTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8347F26824A6EDE7006B7D8A /* DetailTableViewCell.swift */; };
+		8347F26B24A6EDF7006B7D8A /* DetailCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8347F26A24A6EDF7006B7D8A /* DetailCollectionViewCell.swift */; };
 		835209EF24A4A45700648779 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 835209EE24A4A45700648779 /* AppDelegate.swift */; };
 		835209F124A4A45700648779 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 835209F024A4A45700648779 /* SceneDelegate.swift */; };
 		835209F624A4A45700648779 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 835209F424A4A45700648779 /* Main.storyboard */; };
@@ -36,7 +40,11 @@
 /* Begin PBXFileReference section */
 		2A2417A3414DC41E821DB21D /* Pods-AppStore.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppStore.debug.xcconfig"; path = "Target Support Files/Pods-AppStore/Pods-AppStore.debug.xcconfig"; sourceTree = "<group>"; };
 		6760AAD86780A4140A351593 /* Pods-AppStore.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AppStore.release.xcconfig"; path = "Target Support Files/Pods-AppStore/Pods-AppStore.release.xcconfig"; sourceTree = "<group>"; };
+		83478B6A24A7BE0E00C6311C /* Cart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cart.swift; sourceTree = "<group>"; };
 		8347F25C24A6AE8F006B7D8A /* AddItemViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddItemViewController.swift; sourceTree = "<group>"; };
+		8347F26624A6EDB9006B7D8A /* DetailTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailTableViewController.swift; sourceTree = "<group>"; };
+		8347F26824A6EDE7006B7D8A /* DetailTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailTableViewCell.swift; sourceTree = "<group>"; };
+		8347F26A24A6EDF7006B7D8A /* DetailCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailCollectionViewCell.swift; sourceTree = "<group>"; };
 		835209EB24A4A45700648779 /* AppStore.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AppStore.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		835209EE24A4A45700648779 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		835209F024A4A45700648779 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -138,6 +146,7 @@
 				83520A1324A4FAD600648779 /* HomeViewCollectionController.swift */,
 				8347F25C24A6AE8F006B7D8A /* AddItemViewController.swift */,
 				83520A1524A4FFF900648779 /* StartViewController.swift */,
+				8347F26624A6EDB9006B7D8A /* DetailTableViewController.swift */,
 				83520A1E24A625AA00648779 /* ItemTableViewController.swift */,
 			);
 			path = Controller;
@@ -147,6 +156,7 @@
 			isa = PBXGroup;
 			children = (
 				83520A0724A4C11000648779 /* User.swift */,
+				83478B6A24A7BE0E00C6311C /* Cart.swift */,
 				83520A2424A63F0100648779 /* Item.swift */,
 				83520A1924A5183800648779 /* Category.swift */,
 			);
@@ -170,6 +180,8 @@
 				83520A1B24A520D800648779 /* HomeCollectionViewCell.swift */,
 				83520A2024A6262400648779 /* ItemTableViewCell.swift */,
 				83520A2224A6266200648779 /* ItemCollectionViewCell.swift */,
+				8347F26824A6EDE7006B7D8A /* DetailTableViewCell.swift */,
+				8347F26A24A6EDF7006B7D8A /* DetailCollectionViewCell.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -317,13 +329,17 @@
 				83520A1224A4F52A00648779 /* ResetPasswordViewController.swift in Sources */,
 				83520A0524A4B79B00648779 /* LoginViewController.swift in Sources */,
 				83520A1624A4FFF900648779 /* StartViewController.swift in Sources */,
+				8347F26924A6EDE7006B7D8A /* DetailTableViewCell.swift in Sources */,
 				83520A1424A4FAD600648779 /* HomeViewCollectionController.swift in Sources */,
+				8347F26B24A6EDF7006B7D8A /* DetailCollectionViewCell.swift in Sources */,
+				83478B6B24A7BE0E00C6311C /* Cart.swift in Sources */,
 				83520A1F24A625AA00648779 /* ItemTableViewController.swift in Sources */,
 				8347F25D24A6AE8F006B7D8A /* AddItemViewController.swift in Sources */,
 				835209EF24A4A45700648779 /* AppDelegate.swift in Sources */,
 				83520A0E24A4CB7A00648779 /* FirebaseReference.swift in Sources */,
 				835209F124A4A45700648779 /* SceneDelegate.swift in Sources */,
 				83520A1A24A5183800648779 /* Category.swift in Sources */,
+				8347F26724A6EDB9006B7D8A /* DetailTableViewController.swift in Sources */,
 				83520A2124A6262400648779 /* ItemTableViewCell.swift in Sources */,
 				83520A2724A6631F00648779 /* Storage.swift in Sources */,
 				83520A1C24A520D800648779 /* HomeCollectionViewCell.swift in Sources */,

--- a/AppStore/Base.lproj/Main.storyboard
+++ b/AppStore/Base.lproj/Main.storyboard
@@ -496,7 +496,7 @@
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="0c5-jV-gpU">
                                 <rect key="frame" x="0.0" y="88" width="375" height="641"/>
                                 <subviews>
-                                    <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" allowsSelection="NO" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="7bm-Gu-rd9">
+                                    <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="7bm-Gu-rd9">
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="641"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                         <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
@@ -691,11 +691,184 @@
                         <outlet property="sellLabel" destination="Unm-cN-AKz" id="A7U-uM-Zop"/>
                         <outlet property="sellView" destination="hhQ-Le-uaE" id="bEq-xg-MaH"/>
                         <outlet property="tableView" destination="7bm-Gu-rd9" id="Zb2-w4-8Dk"/>
+                        <segue destination="Mtt-TG-UJB" kind="show" identifier="detailVC" id="lWZ-jY-ZOB"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="y1o-Yd-TXn" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="6356" y="-235.71428571428572"/>
+        </scene>
+        <!--Detail Table View Controller-->
+        <scene sceneID="I4u-8l-7oh">
+            <objects>
+                <viewController storyboardIdentifier="DetailVC" useStoryboardIdentifierAsRestorationIdentifier="YES" id="Mtt-TG-UJB" customClass="DetailTableViewController" customModule="AppStore" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="LGh-FM-R2b">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="peF-Ho-arg">
+                                <rect key="frame" x="0.0" y="88" width="375" height="591"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <collectionView key="tableHeaderView" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" id="B6g-Ck-Cd8">
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="277"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                    <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="10" minimumInteritemSpacing="10" id="2Bu-vd-fdm">
+                                        <size key="itemSize" width="128" height="128"/>
+                                        <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                                        <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                                        <inset key="sectionInset" minX="62" minY="10" maxX="0.0" maxY="10"/>
+                                    </collectionViewFlowLayout>
+                                    <cells>
+                                        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="Cell" id="6Iu-QV-xtd" customClass="DetailCollectionViewCell" customModule="AppStore" customModuleProvider="target">
+                                            <rect key="frame" x="62" y="18" width="250" height="241"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                            <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="esC-hQ-Kwp">
+                                                <rect key="frame" x="0.0" y="0.0" width="250" height="241"/>
+                                                <autoresizingMask key="autoresizingMask"/>
+                                                <subviews>
+                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="eRG-am-bPu">
+                                                        <rect key="frame" x="0.0" y="0.0" width="250" height="241"/>
+                                                    </imageView>
+                                                </subviews>
+                                                <constraints>
+                                                    <constraint firstItem="eRG-am-bPu" firstAttribute="leading" secondItem="esC-hQ-Kwp" secondAttribute="leading" id="Bhb-d0-fpn"/>
+                                                    <constraint firstAttribute="bottom" secondItem="eRG-am-bPu" secondAttribute="bottom" id="KcF-1D-PJP"/>
+                                                    <constraint firstAttribute="trailing" secondItem="eRG-am-bPu" secondAttribute="trailing" id="Lry-HH-hZu"/>
+                                                    <constraint firstItem="eRG-am-bPu" firstAttribute="top" secondItem="esC-hQ-Kwp" secondAttribute="top" id="VGH-dQ-zWW"/>
+                                                </constraints>
+                                            </collectionViewCellContentView>
+                                            <size key="customSize" width="250" height="241"/>
+                                            <connections>
+                                                <outlet property="imageView" destination="eRG-am-bPu" id="w1q-aI-qDd"/>
+                                            </connections>
+                                        </collectionViewCell>
+                                    </cells>
+                                </collectionView>
+                                <prototypes>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="Cell" rowHeight="129" id="MCf-hS-AuL" customClass="DetailTableViewCell" customModule="AppStore" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="305" width="375" height="129"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="MCf-hS-AuL" id="0XA-Bb-xRV">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="129"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="DescriptionLabel" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="R86-O7-Rid">
+                                                    <rect key="frame" x="20" y="81.666666666666671" width="335" height="19.333333333333329"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="価格:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="V8f-WL-SyU">
+                                                    <rect key="frame" x="20.000000000000004" y="49" width="39.333333333333343" height="21"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="PriceLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pzA-9Q-DV9">
+                                                    <rect key="frame" x="64.333333333333314" y="47.666666666666664" width="91.666666666666686" height="23.999999999999993"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                                    <color key="textColor" systemColor="systemRedColor" red="1" green="0.23137254900000001" blue="0.18823529410000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="NameLabel" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Gxv-uX-bJC">
+                                                    <rect key="frame" x="20" y="10" width="335" height="24"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                                    <color key="textColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="YOZ-lK-xhI">
+                                                    <rect key="frame" x="20" y="0.0" width="335" height="1"/>
+                                                    <color key="backgroundColor" systemColor="systemGray4Color" red="0.81960784310000001" green="0.81960784310000001" blue="0.83921568629999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" constant="1" id="v2K-p1-g9F"/>
+                                                    </constraints>
+                                                </view>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="V8f-WL-SyU" firstAttribute="top" secondItem="Gxv-uX-bJC" secondAttribute="bottom" constant="15" id="1EO-3k-uxS"/>
+                                                <constraint firstAttribute="trailing" secondItem="R86-O7-Rid" secondAttribute="trailing" constant="20" id="6ix-D4-2s1"/>
+                                                <constraint firstItem="pzA-9Q-DV9" firstAttribute="leading" secondItem="V8f-WL-SyU" secondAttribute="trailing" constant="5" id="6zP-mV-nEn"/>
+                                                <constraint firstItem="R86-O7-Rid" firstAttribute="top" secondItem="pzA-9Q-DV9" secondAttribute="bottom" constant="10" id="7SV-OF-Oha"/>
+                                                <constraint firstItem="pzA-9Q-DV9" firstAttribute="centerY" secondItem="V8f-WL-SyU" secondAttribute="centerY" id="Fhs-Rw-Dsz"/>
+                                                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="R86-O7-Rid" secondAttribute="bottom" constant="20" id="GMb-wj-Uuy"/>
+                                                <constraint firstItem="R86-O7-Rid" firstAttribute="leading" secondItem="0XA-Bb-xRV" secondAttribute="leading" constant="20" id="Nlv-g6-YTv"/>
+                                                <constraint firstAttribute="trailingMargin" relation="greaterThanOrEqual" secondItem="pzA-9Q-DV9" secondAttribute="trailing" id="Q9w-vI-SIk"/>
+                                                <constraint firstItem="YOZ-lK-xhI" firstAttribute="top" secondItem="0XA-Bb-xRV" secondAttribute="top" id="QvM-yT-ply"/>
+                                                <constraint firstItem="V8f-WL-SyU" firstAttribute="leading" secondItem="0XA-Bb-xRV" secondAttribute="leading" constant="20" id="UJ0-vm-e3q"/>
+                                                <constraint firstAttribute="trailing" secondItem="Gxv-uX-bJC" secondAttribute="trailing" constant="20" id="YEZ-pm-Q29"/>
+                                                <constraint firstItem="Gxv-uX-bJC" firstAttribute="top" secondItem="0XA-Bb-xRV" secondAttribute="top" constant="10" id="bsb-q4-E7k"/>
+                                                <constraint firstItem="Gxv-uX-bJC" firstAttribute="leading" secondItem="0XA-Bb-xRV" secondAttribute="leading" constant="20" id="qPh-01-XS8"/>
+                                                <constraint firstAttribute="trailing" secondItem="YOZ-lK-xhI" secondAttribute="trailing" constant="20" id="vaM-4C-VIj"/>
+                                                <constraint firstItem="YOZ-lK-xhI" firstAttribute="leading" secondItem="0XA-Bb-xRV" secondAttribute="leading" constant="20" id="wVX-hk-Fh4"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <outlet property="descriptionLabel" destination="R86-O7-Rid" id="4hY-yF-7o5"/>
+                                            <outlet property="nameLabel" destination="Gxv-uX-bJC" id="mcW-ea-wJJ"/>
+                                            <outlet property="priceLabel" destination="pzA-9Q-DV9" id="hZC-7H-3K3"/>
+                                        </connections>
+                                    </tableViewCell>
+                                </prototypes>
+                                <connections>
+                                    <outlet property="dataSource" destination="Mtt-TG-UJB" id="jgJ-hg-cby"/>
+                                    <outlet property="delegate" destination="Mtt-TG-UJB" id="dkl-oq-V5i"/>
+                                </connections>
+                            </tableView>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ySv-Dd-LyH">
+                                <rect key="frame" x="0.0" y="679" width="375" height="50"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pzO-1w-W3C">
+                                        <rect key="frame" x="20" y="7.6666666666666288" width="335" height="35"/>
+                                        <color key="backgroundColor" name="original yellow"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="35" id="EdP-7g-Qw6"/>
+                                        </constraints>
+                                        <state key="normal" title="カートに入れる">
+                                            <color key="titleColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        </state>
+                                        <connections>
+                                            <action selector="cartButtonPressed:" destination="Mtt-TG-UJB" eventType="touchUpInside" id="yxt-TS-V4G"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <constraints>
+                                    <constraint firstItem="pzO-1w-W3C" firstAttribute="centerY" secondItem="ySv-Dd-LyH" secondAttribute="centerY" id="2Rw-kF-yh0"/>
+                                    <constraint firstAttribute="height" constant="50" id="A3g-VI-ufk"/>
+                                    <constraint firstAttribute="trailing" secondItem="pzO-1w-W3C" secondAttribute="trailing" constant="20" id="Et9-R9-9kA"/>
+                                    <constraint firstItem="pzO-1w-W3C" firstAttribute="leading" secondItem="ySv-Dd-LyH" secondAttribute="leading" constant="20" id="ZjX-WI-qnO"/>
+                                </constraints>
+                            </view>
+                        </subviews>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstItem="ySv-Dd-LyH" firstAttribute="top" secondItem="peF-Ho-arg" secondAttribute="bottom" id="3SK-tD-BqX"/>
+                            <constraint firstItem="peF-Ho-arg" firstAttribute="trailing" secondItem="CWJ-b7-2yC" secondAttribute="trailing" id="F6g-AU-tXj"/>
+                            <constraint firstItem="ySv-Dd-LyH" firstAttribute="bottom" secondItem="CWJ-b7-2yC" secondAttribute="bottom" id="GKF-o3-jF2"/>
+                            <constraint firstItem="peF-Ho-arg" firstAttribute="leading" secondItem="CWJ-b7-2yC" secondAttribute="leading" id="JfA-Up-qyI"/>
+                            <constraint firstItem="peF-Ho-arg" firstAttribute="top" secondItem="CWJ-b7-2yC" secondAttribute="top" id="cZX-vt-y4O"/>
+                            <constraint firstItem="CWJ-b7-2yC" firstAttribute="trailing" secondItem="ySv-Dd-LyH" secondAttribute="trailing" id="eBJ-7Z-YdC"/>
+                            <constraint firstItem="ySv-Dd-LyH" firstAttribute="leading" secondItem="CWJ-b7-2yC" secondAttribute="leading" id="iuE-db-Z5v"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="CWJ-b7-2yC"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="Ifl-Hg-xI8">
+                        <barButtonItem key="leftBarButtonItem" image="back" id="pEa-Vp-f1I">
+                            <connections>
+                                <action selector="backButtonPressed:" destination="Mtt-TG-UJB" id="FVl-id-EIK"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
+                    <connections>
+                        <outlet property="cartButton" destination="pzO-1w-W3C" id="bJz-V8-2AW"/>
+                        <outlet property="collectionView" destination="B6g-Ck-Cd8" id="4b0-zV-6oR"/>
+                        <outlet property="tableView" destination="peF-Ho-arg" id="DjK-gj-LKO"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="frU-h4-8yu" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="7240.8000000000002" y="-895.56650246305423"/>
         </scene>
         <!--商品の情報を入力-->
         <scene sceneID="nzC-SW-QLe">
@@ -759,7 +932,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="出品を決定しますか？" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZoO-rf-b0o">
-                                <rect key="frame" x="101.00000000000001" y="643" width="173.33333333333337" height="21"/>
+                                <rect key="frame" x="101.00000000000001" y="648" width="173.33333333333337" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -790,7 +963,7 @@
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Z2x-8X-FU2">
-                                <rect key="frame" x="20" y="674" width="335" height="35"/>
+                                <rect key="frame" x="20" y="679" width="335" height="35"/>
                                 <color key="backgroundColor" name="original yellow"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="35" id="4ha-EB-3P2"/>
@@ -885,7 +1058,7 @@
                             <constraint firstItem="SnN-mj-cxR" firstAttribute="leading" secondItem="vOW-8C-kzt" secondAttribute="leading" constant="20" id="d57-KE-wMC"/>
                             <constraint firstItem="GDa-k4-6GT" firstAttribute="leading" secondItem="vOW-8C-kzt" secondAttribute="leading" constant="20" id="e4C-ft-38o"/>
                             <constraint firstItem="Z2x-8X-FU2" firstAttribute="leading" secondItem="vOW-8C-kzt" secondAttribute="leading" constant="20" id="eik-P1-mUc"/>
-                            <constraint firstItem="vOW-8C-kzt" firstAttribute="bottom" secondItem="Z2x-8X-FU2" secondAttribute="bottom" constant="20" id="gJE-sk-2oB"/>
+                            <constraint firstItem="vOW-8C-kzt" firstAttribute="bottom" secondItem="Z2x-8X-FU2" secondAttribute="bottom" constant="15" id="gJE-sk-2oB"/>
                             <constraint firstItem="vOW-8C-kzt" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Vcu-JD-eJx" secondAttribute="trailing" id="jwD-We-6i1"/>
                             <constraint firstItem="Vcu-JD-eJx" firstAttribute="centerY" secondItem="fef-Ni-lqj" secondAttribute="centerY" id="l9N-Aj-OsB"/>
                             <constraint firstAttribute="trailing" secondItem="q5D-mf-z3i" secondAttribute="trailing" constant="20" id="ln1-3z-Hs0"/>

--- a/AppStore/Base.lproj/Main.storyboard
+++ b/AppStore/Base.lproj/Main.storyboard
@@ -389,14 +389,14 @@
                     </tabBar>
                     <connections>
                         <segue destination="qw9-Pl-wyU" kind="relationship" relationship="viewControllers" id="obS-Kp-TNH"/>
-                        <segue destination="e9C-VA-wDS" kind="relationship" relationship="viewControllers" id="z0o-M6-g3M"/>
+                        <segue destination="jag-Y1-nbl" kind="relationship" relationship="viewControllers" id="z0o-M6-g3M"/>
                     </connections>
                 </tabBarController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Qfl-Nm-6A2" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="3708" y="113.79310344827587"/>
         </scene>
-        <!--Item-->
+        <!--View Controller-->
         <scene sceneID="vcE-fj-XKQ">
             <objects>
                 <viewController id="e9C-VA-wDS" sceneMemberID="viewController">
@@ -406,13 +406,13 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <viewLayoutGuide key="safeArea" id="LZL-N0-BQV"/>
                     </view>
-                    <tabBarItem key="tabBarItem" title="Item" id="Oz3-Bv-UsP"/>
+                    <navigationItem key="navigationItem" id="VXD-aa-jnE"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="wzv-0R-Ow7" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="4649" y="503"/>
+            <point key="canvasLocation" x="5591.1999999999998" y="502.46305418719214"/>
         </scene>
-        <!--AppStore-->
+        <!--Home View Collection Controller-->
         <scene sceneID="FZK-rs-hk8">
             <objects>
                 <collectionViewController id="6k9-Y5-Pbl" customClass="HomeViewCollectionController" customModule="AppStore" customModuleProvider="target" sceneMemberID="viewController">
@@ -470,7 +470,7 @@
                             <outlet property="delegate" destination="6k9-Y5-Pbl" id="IaG-kJ-PyD"/>
                         </connections>
                     </collectionView>
-                    <navigationItem key="navigationItem" title="AppStore" id="SYy-kR-6uS">
+                    <navigationItem key="navigationItem" id="SYy-kR-6uS">
                         <barButtonItem key="leftBarButtonItem" title="ログアウト" id="KXm-31-xML">
                             <connections>
                                 <action selector="logoutButtonPressed:" destination="6k9-Y5-Pbl" id="wzz-vb-AYW"/>
@@ -565,19 +565,19 @@
                                                                 <constraint firstAttribute="width" constant="130" id="czY-HK-bPM"/>
                                                             </constraints>
                                                         </imageView>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="description" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="5" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Uw2-ov-1ok">
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="DescriptionLabel" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="5" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Uw2-ov-1ok">
                                                             <rect key="frame" x="155" y="38.333333333333336" width="210" height="20.333333333333336"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="¥100" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wGy-NO-WS1">
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="PriceLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wGy-NO-WS1">
                                                             <rect key="frame" x="155" y="73.666666666666671" width="210" height="24"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                                             <color key="textColor" systemColor="systemRedColor" red="1" green="0.23137254900000001" blue="0.18823529410000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8LQ-xn-4Y8">
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="NameLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8LQ-xn-4Y8">
                                                             <rect key="frame" x="155" y="9.9999999999999982" width="210" height="20.333333333333329"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                             <nil key="textColor"/>
@@ -707,7 +707,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="peF-Ho-arg">
-                                <rect key="frame" x="0.0" y="88" width="375" height="591"/>
+                                <rect key="frame" x="0.0" y="88" width="375" height="581"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <collectionView key="tableHeaderView" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" id="B6g-Ck-Cd8">
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="277"/>
@@ -816,10 +816,10 @@
                                 </connections>
                             </tableView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ySv-Dd-LyH">
-                                <rect key="frame" x="0.0" y="679" width="375" height="50"/>
+                                <rect key="frame" x="0.0" y="669" width="375" height="60"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pzO-1w-W3C">
-                                        <rect key="frame" x="20" y="7.6666666666666288" width="335" height="35"/>
+                                        <rect key="frame" x="20" y="12.666666666666629" width="335" height="35"/>
                                         <color key="backgroundColor" name="original yellow"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="35" id="EdP-7g-Qw6"/>
@@ -835,7 +835,7 @@
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <constraints>
                                     <constraint firstItem="pzO-1w-W3C" firstAttribute="centerY" secondItem="ySv-Dd-LyH" secondAttribute="centerY" id="2Rw-kF-yh0"/>
-                                    <constraint firstAttribute="height" constant="50" id="A3g-VI-ufk"/>
+                                    <constraint firstAttribute="height" constant="60" id="A3g-VI-ufk"/>
                                     <constraint firstAttribute="trailing" secondItem="pzO-1w-W3C" secondAttribute="trailing" constant="20" id="Et9-R9-9kA"/>
                                     <constraint firstItem="pzO-1w-W3C" firstAttribute="leading" secondItem="ySv-Dd-LyH" secondAttribute="leading" constant="20" id="ZjX-WI-qnO"/>
                                 </constraints>
@@ -843,7 +843,7 @@
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <constraints>
-                            <constraint firstItem="ySv-Dd-LyH" firstAttribute="top" secondItem="peF-Ho-arg" secondAttribute="bottom" id="3SK-tD-BqX"/>
+                            <constraint firstItem="ySv-Dd-LyH" firstAttribute="top" secondItem="peF-Ho-arg" secondAttribute="bottom" id="19Q-Mt-jma"/>
                             <constraint firstItem="peF-Ho-arg" firstAttribute="trailing" secondItem="CWJ-b7-2yC" secondAttribute="trailing" id="F6g-AU-tXj"/>
                             <constraint firstItem="ySv-Dd-LyH" firstAttribute="bottom" secondItem="CWJ-b7-2yC" secondAttribute="bottom" id="GKF-o3-jF2"/>
                             <constraint firstItem="peF-Ho-arg" firstAttribute="leading" secondItem="CWJ-b7-2yC" secondAttribute="leading" id="JfA-Up-qyI"/>
@@ -870,7 +870,7 @@
             </objects>
             <point key="canvasLocation" x="7240.8000000000002" y="-895.56650246305423"/>
         </scene>
-        <!--商品の情報を入力-->
+        <!--Add Item View Controller-->
         <scene sceneID="nzC-SW-QLe">
             <objects>
                 <viewController id="Mwz-lF-f4f" customClass="AddItemViewController" customModule="AppStore" customModuleProvider="target" sceneMemberID="viewController">
@@ -1074,7 +1074,7 @@
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="vOW-8C-kzt"/>
                     </view>
-                    <navigationItem key="navigationItem" title="商品の情報を入力" id="6ra-Cx-TA1">
+                    <navigationItem key="navigationItem" id="6ra-Cx-TA1">
                         <barButtonItem key="leftBarButtonItem" image="back" id="HXn-dZ-sze">
                             <connections>
                                 <action selector="backButtonPressed:" destination="Mwz-lF-f4f" id="9gZ-6x-1Cs"/>
@@ -1131,9 +1131,30 @@
             </objects>
             <point key="canvasLocation" x="4650" y="-235"/>
         </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="TUc-Kb-qcY">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="jag-Y1-nbl" sceneMemberID="viewController">
+                    <tabBarItem key="tabBarItem" title="" image="cart" catalog="system" selectedImage="cart.fill" id="Oz3-Bv-UsP"/>
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="faq-So-I2Y">
+                        <rect key="frame" x="0.0" y="44" width="375" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="e9C-VA-wDS" kind="relationship" relationship="rootViewController" id="9IE-np-NIP"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Gah-5g-PBf" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="4648.8000000000002" y="502.46305418719214"/>
+        </scene>
     </scenes>
     <resources>
         <image name="back" width="30" height="30"/>
+        <image name="cart" catalog="system" width="128" height="102"/>
+        <image name="cart.fill" catalog="system" width="128" height="102"/>
         <image name="house" catalog="system" width="128" height="110"/>
         <image name="house.fill" catalog="system" width="128" height="106"/>
         <namedColor name="original yellow">

--- a/AppStore/Controller/AddItemViewController.swift
+++ b/AppStore/Controller/AddItemViewController.swift
@@ -37,6 +37,7 @@ class AddItemViewController: UIViewController, UITextFieldDelegate {
     
     private func setupUI() {
         
+        self.title = "商品の情報を入力"
         textViewBorder.layer.borderWidth = 1
         textViewBorder.layer.borderColor = UIColor.systemGray4.cgColor
         textViewBorder.layer.cornerRadius = 5

--- a/AppStore/Controller/CreateAccountViewController.swift
+++ b/AppStore/Controller/CreateAccountViewController.swift
@@ -146,6 +146,4 @@ class CreateAccountViewController: UIViewController, UITextFieldDelegate {
         }
     }
     
-    
-
 }

--- a/AppStore/Controller/DetailTableViewController.swift
+++ b/AppStore/Controller/DetailTableViewController.swift
@@ -1,0 +1,171 @@
+//
+//  DetailTableViewController.swift
+//  AppStore
+//
+//  Created by yuji_nakamoto on 2020/06/27.
+//  Copyright © 2020 yuji_nakamoto. All rights reserved.
+//
+
+import UIKit
+import JGProgressHUD
+
+class DetailTableViewController: UIViewController {
+    
+    @IBOutlet weak var tableView: UITableView!
+    @IBOutlet weak var collectionView: UICollectionView!
+    @IBOutlet weak var cartButton: UIButton!
+    
+    var item: Item!
+    var itemArray: [Item] = []
+    var itemImages: [UIImage] = []
+    let hud = JGProgressHUD(style: .dark)
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        collectionView.delegate = self
+        collectionView.dataSource = self
+        tableView.tableFooterView = UIView()
+        cartButton.layer.cornerRadius = 10
+        
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        downloadPicture()
+    }
+    
+    //MARK: IBAction
+    
+    @IBAction func cartButtonPressed(_ sender: Any) {
+        
+        downloadCartFromFirestore(User.currentUserId()) { (cart) in
+            
+            if cart == nil {
+                self.createNewCart()
+            } else {
+                cart!.itemIds.append(self.item.id)
+                self.updateCart(cart: cart!, withValues: [ITEMIDS : cart!.itemIds!])
+            }
+        }
+    }
+    
+    @IBAction func backButtonPressed(_ sender: Any) {
+        
+        self.navigationController?.popViewController(animated: true)
+    }
+    
+    
+    //MARK: Load Picture
+    private func downloadPicture() {
+        
+        if item != nil && item.imageLinks != nil {
+            downloadImages(imageUrls: item.imageLinks) { (allImages) in
+                if allImages.count > 0 {
+                    self.itemImages = allImages as! [UIImage]
+                    self.collectionView.reloadData()
+                }
+            }
+        }
+    }
+    
+    //MARK: Add to basket
+    
+    private func createNewCart() {
+        
+        let newCart = Cart()
+        
+        if User.currentUserId() == "" {
+            newCart.ownerId = "1234"
+        } else {
+            newCart.ownerId = User.currentUserId()
+        }
+        newCart.id = UUID().uuidString
+        newCart.itemIds = [self.item.id]
+        saveCartToFirestore(newCart)
+        
+        hud.textLabel.text = "カートに追加しました"
+        hudSuccess()
+    }
+    
+    private func updateCart(cart: Cart, withValues: [String: Any]) {
+        
+        updateCartInFirestore(cart, withValue: withValues) { (error) in
+            
+            if error != nil {
+                
+                self.hud.textLabel.text = "Error: \(error!.localizedDescription)"
+                self.hudError()
+                print("error updating basket", error!.localizedDescription)
+            } else {
+                self.hud.textLabel.text = "Add to basket"
+                self.hudSuccess()
+            }
+        }
+    }
+    
+    //MARK: Helper Function
+    
+    private func hudError() {
+        
+        hud.indicatorView = JGProgressHUDErrorIndicatorView()
+        hud.show(in: self.view)
+        hud.dismiss(afterDelay: 2.0)
+    }
+    
+    private func hudSuccess() {
+        
+        hud.indicatorView = JGProgressHUDSuccessIndicatorView()
+        hud.show(in: self.view)
+        hud.dismiss(afterDelay: 2.0)
+    }
+    
+}
+
+//MARK: CollectionView Function
+
+extension DetailTableViewController:  UICollectionViewDataSource, UICollectionViewDelegate, UICollectionViewDelegateFlowLayout {
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        
+        return CGSize(width: 250, height: 250)
+    }
+    
+    
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return itemImages.count == 0 ? 1 : itemImages.count
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "Cell", for: indexPath) as! DetailCollectionViewCell
+        
+        if itemImages.count > 0 {
+            cell.setupImageWith(itemImage: itemImages[indexPath.row])
+        }
+        return cell
+    }
+    
+}
+
+//MARK: TableView Function
+
+extension DetailTableViewController: UITableViewDelegate, UITableViewDataSource {
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 1
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        
+        let cell = tableView.dequeueReusableCell(withIdentifier: "Cell", for: indexPath) as! DetailTableViewCell
+        
+        cell.nameLabel.text = item.name
+        cell.priceLabel.text = "¥\(String(item.price))"
+        cell.descriptionLabel.text = item.descriprion
+        
+        return cell
+    }
+    
+}

--- a/AppStore/Controller/DetailTableViewController.swift
+++ b/AppStore/Controller/DetailTableViewController.swift
@@ -23,6 +23,7 @@ class DetailTableViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        self.title = "商品の詳細"
         collectionView.delegate = self
         collectionView.dataSource = self
         tableView.tableFooterView = UIView()
@@ -99,7 +100,7 @@ class DetailTableViewController: UIViewController {
                 self.hudError()
                 print("error updating basket", error!.localizedDescription)
             } else {
-                self.hud.textLabel.text = "Add to basket"
+                self.hud.textLabel.text = "カートに追加しました"
                 self.hudSuccess()
             }
         }
@@ -159,7 +160,7 @@ extension DetailTableViewController: UITableViewDelegate, UITableViewDataSource 
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         
-        let cell = tableView.dequeueReusableCell(withIdentifier: "Cell", for: indexPath) as! DetailTableViewCell
+        let cell = tableView.dequeueReusableCell(withIdentifier: "Cell") as! DetailTableViewCell
         
         cell.nameLabel.text = item.name
         cell.priceLabel.text = "¥\(String(item.price))"

--- a/AppStore/Controller/HomeViewCollectionController.swift
+++ b/AppStore/Controller/HomeViewCollectionController.swift
@@ -19,6 +19,7 @@ class HomeViewCollectionController: UICollectionViewController {
         super.viewDidLoad()
         
 //        createCategorySet()
+        self.title = "App Store"
         loadCategory()
     }
     

--- a/AppStore/Controller/ItemTableViewController.swift
+++ b/AppStore/Controller/ItemTableViewController.swift
@@ -83,10 +83,10 @@ class ItemTableViewController: UIViewController {
     //MARK: Prepare Function
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        if segue.identifier == "AddItemVC" {
-            
-            let addVC = segue.destination as! AddItemViewController
-            addVC.category = category!
+        if segue.identifier == "detailVC" {
+
+            let detailVC = segue.destination as! DetailTableViewController
+            detailVC.item = sender as? Item
         }
     }
     
@@ -116,7 +116,8 @@ extension ItemTableViewController:  UICollectionViewDataSource, UICollectionView
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-
+        
+        performSegue(withIdentifier: "detailVC", sender: itemArray[indexPath.row])
     }
 }
 
@@ -143,7 +144,8 @@ extension ItemTableViewController: UITableViewDelegate, UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        
-        
+
+        performSegue(withIdentifier: "detailVC", sender: itemArray[indexPath.row])
     }
+    
 }

--- a/AppStore/Helpers/Constants.swift
+++ b/AppStore/Helpers/Constants.swift
@@ -25,9 +25,14 @@ public let NAME = "name"
 public let IMAGENAME = "imageName"
 public let CATEGORYSET = "categorySet"
 
+//Item
 public let CATEGORYID = "categoryId"
 public let DESCRIPTION = "description"
 public let PRICE = "price"
 public let IMAGELINKS = "imageLinks"
+
+//Cart
+public let OWNERID = "ownerId"
+public let ITEMIDS = "itemIds"
 
 

--- a/AppStore/Helpers/FirebaseReference.swift
+++ b/AppStore/Helpers/FirebaseReference.swift
@@ -13,10 +13,9 @@ enum FCollectionReference: String {
     case User
     case Category
     case Items
-    case Basket
+    case Cart
 }
 
 func firebaseRef(_ collectionReference: FCollectionReference) -> CollectionReference {
-    
     return Firestore.firestore().collection(collectionReference.rawValue)
 }

--- a/AppStore/Model/Cart.swift
+++ b/AppStore/Model/Cart.swift
@@ -1,0 +1,63 @@
+//
+//  Cart.swift
+//  AppStore
+//
+//  Created by yuji_nakamoto on 2020/06/28.
+//  Copyright © 2020 yuji_nakamoto. All rights reserved.
+//
+
+import Foundation
+
+class Cart {
+    
+    var id: String!
+    var ownerId: String!
+    var itemIds: [String]!
+    
+    init() {
+    }
+    
+    init(dict: NSDictionary) {
+        id = dict[USERID] as? String
+        ownerId = dict[OWNERID] as? String
+        itemIds = dict[ITEMIDS] as? [String]
+    }
+}
+
+//MARK: Download items
+func downloadCartFromFirestore(_ ownerId: String, completion: @escaping (_ cart: Cart?) -> Void) {
+    
+    firebaseRef(.Cart).whereField(OWNERID, isEqualTo: ownerId).getDocuments { (snapshot, error) in
+        guard let snapshot = snapshot else {
+            completion(nil)
+            return
+        }
+        
+        if !snapshot.isEmpty && snapshot.documents.count > 0 {
+            let cart = Cart(dict: snapshot.documents.first!.data() as NSDictionary)
+            completion(cart)
+        } else {
+            completion(nil)
+        }
+    }
+}
+
+//MARK: Save to Firebase
+func saveCartToFirestore(_ cart: Cart) {
+    
+    firebaseRef(.Cart).document(cart.id).setData(cartDictionaryFrom(cart) as! [String: Any])
+}
+
+//MARK: Helper functions
+
+func cartDictionaryFrom(_ cart: Cart) -> NSDictionary {
+    return NSDictionary(objects: [cart.id ?? "", cart.ownerId ?? "", cart.itemIds ?? ""], forKeys: [USERID as NSCopying, OWNERID as NSCopying, ITEMIDS as NSCopying])
+}
+
+//MARK: Update basket
+func updateCartInFirestore(_ cart: Cart, withValue: [String: Any], completion: @escaping (_ error: Error?) -> Void) {
+    
+    firebaseRef(.Cart).document(cart.id).updateData(withValue) { (error) in
+        completion(error)
+    }
+}

--- a/AppStore/View/DetailCollectionViewCell.swift
+++ b/AppStore/View/DetailCollectionViewCell.swift
@@ -1,0 +1,21 @@
+//
+//  DetailCollectionViewCell.swift
+//  AppStore
+//
+//  Created by yuji_nakamoto on 2020/06/27.
+//  Copyright © 2020 yuji_nakamoto. All rights reserved.
+//
+
+import UIKit
+
+class DetailCollectionViewCell: UICollectionViewCell {
+    
+    @IBOutlet weak var imageView: UIImageView!
+    
+    func setupImageWith(itemImage: UIImage) {
+        
+        imageView.image = itemImage
+    }
+
+    
+}

--- a/AppStore/View/DetailTableViewCell.swift
+++ b/AppStore/View/DetailTableViewCell.swift
@@ -1,0 +1,30 @@
+//
+//  DetailTableViewCell.swift
+//  AppStore
+//
+//  Created by yuji_nakamoto on 2020/06/27.
+//  Copyright © 2020 yuji_nakamoto. All rights reserved.
+//
+
+import UIKit
+
+class DetailTableViewCell: UITableViewCell {
+    
+    
+    @IBOutlet weak var nameLabel: UILabel!
+    @IBOutlet weak var priceLabel: UILabel!
+    @IBOutlet weak var descriptionLabel: UILabel!
+
+    
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        // Initialization code
+    }
+    
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+        
+        // Configure the view for the selected state
+    }
+    
+}


### PR DESCRIPTION
＃What
・商品一覧から商品詳細ビューへ遷移が可能。
・商品詳細ビューから、その商品をカートに追加することが可能。

＃Why
・商品を詳しく確認するため。
・商品を購入するため。

・UI,UX　↓
https://gyazo.com/37d5babf286edcd31b0bcf2d3152421c